### PR TITLE
We're doing it live

### DIFF
--- a/celery_utils/chunked_callback_task.py
+++ b/celery_utils/chunked_callback_task.py
@@ -1,0 +1,49 @@
+"""
+Parallelize a large task and join the results, using a database backend without a busy wait
+"""
+
+
+def chunk_task(task, std_args, itr_arg_name, itr_arg, chunk_size, callback, callback_args):
+    """
+    Start a bunch of subtasks with a joined callback to follow.
+
+        task: the task to run as subtasks
+        std_args: task arguments that do not change
+        itr_arg_name: the name of the argument to be chunked
+        itr_arg: the (unchunked) argument to be chunked, a list
+        chunk_size: the number of items to put in each chunk
+        callback: the task to run after all subtasks have finished
+        callback_args: callback arguments that do not depend on the results of subtasks
+    """
+    parent = TaskCounter()
+    parent.save()  # if we knew the total length of itr_arg here, we could set parent.expected before saving and remove all the "lock" nonsense
+
+    def maybe_callback():
+        if TaskCounter.is_finished(parent.id):
+            callback_sig = callback.s(callback_args)
+            callback_sig.apply_async(
+                TaskCounter.results_itr(parent.id),
+                link=TaskCounter.cleanup_after_callback
+            )
+
+    exhausted = False
+    while not exhausted:
+        itr_arg_list = []
+        for _ in range(chunk_size):
+            try:
+                itr_arg_list.append(itr_arg.next())
+            except StopIteration:
+                exhausted = True
+        parent.expected = parent.expected + 1
+        subtask = task.s(**std_args.update({itr_arg_name: itr_arg_list}))
+        t = subtask.freeze()
+
+        def update_and_maybe_callback():
+            TaskCounter.update(parent.id, t)
+            maybe_callback()
+
+        t.apply_async(link=update_and_maybe_callback)
+
+    parent.locked = False
+    parent.save()
+    maybe_callback()

--- a/celery_utils/migrations/0002_backend_cleanup.py
+++ b/celery_utils/migrations/0002_backend_cleanup.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('celery_utils', '0001_initial'),
+        ('djcelery', '0001_initial'),
+    ]
+
+    operations = [
+    ]

--- a/celery_utils/migrations/0003_task_counter.py
+++ b/celery_utils/migrations/0003_task_counter.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djcelery', '0001_initial'),
+        ('celery_utils', '0002_backend_cleanup'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TaskCounter',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('expected', models.IntegerField(default=0)),
+                ('locked', models.BooleanField(default=True)),
+                ('completed_subtasks', models.ManyToManyField(to='djcelery.TaskMeta')),
+            ],
+        ),
+    ]

--- a/celery_utils/models.py
+++ b/celery_utils/models.py
@@ -11,6 +11,7 @@ from celery import current_app
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
+from djcelery.models import TaskMeta
 
 from jsonfield import JSONField
 from model_utils.models import TimeStampedModel
@@ -18,6 +19,42 @@ from model_utils.models import TimeStampedModel
 from . import tasks
 
 log = logging.getLogger(__name__)
+
+
+class TaskCounter(models.Model):
+    """
+    A naive model to track subtask completion.
+    """
+    expected = models.IntegerField(default=0)
+    completed_subtasks = models.ManyToManyField(TaskMeta)
+    locked = models.BooleanField(default=True)  # prevent callback until all subtasks have spawned
+
+    @classmethod
+    def update(cls, _id, task):
+        counter = cls.objects.select_for_update().get(id=_id)
+        counter.completed_subtasks.add(task)
+        counter.save()
+
+    @classmethod
+    def is_finished(cls, _id):
+        counter = cls.objects.get(id=_id)
+        return (
+            not counter.locked and
+            counter.completed_subtasks.filter(state='SUCCESS').count() >= counter.expected
+        )
+
+    @classmethod
+    def results_itr(cls, _id):
+        counter = cls.objects.get(id=_id)
+        for subtask in counter.completed_subtasks:
+            yield subtask.result
+
+    @classmethod
+    def cleanup_after_callback(cls, _id):
+        counter = cls.objects.get(id=_id)
+        for subtask in counter.completed_subtasks:
+            subtask.delete()
+        counter.delete()
 
 
 @python_2_unicode_compatible

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,5 +2,6 @@
 
 celery >= 3.1,<5.0
 Django                    # Web application framework
+django-celery==3.2.1
 django-model-utils
 jsonfield


### PR DESCRIPTION
Celery only supports good chords (no busy waits) if we use Redis or Memcached as the results backend. Redis is a no go for devops reasons, memcached is a no go for operational reasons, and busy waits are awful, so here's where we are.

This is my first pass at approximating the non busy wait approach, using a django-celery backed results store. LMK what you think, suggestions welcome

FYI @edx/educator-neem @jibsheet 