### PR TITLE
ChordableDjangoBackend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ python:
 - 3.5
 env:
 - TOXENV=django18-celery3
-- TOXENV=django18-celery4
-- TOXENV=django19-celery4
-- TOXENV=django110-celery4
+- TOXENV=django19-celery3
+- TOXENV=django110-celery3
 matrix:
   include:
   - python: 3.5

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 J. Cliff Dyer <cdyer@edx.org>
+Eric Fischer <efischer@edx.org>

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ requirements: ## install development environment requirements
 	pip-sync requirements/base.txt requirements/dev.txt requirements/private.* requirements/test.txt
 
 test: clean ## run tests in the current virtualenv
-	py.test
+	py.test tests/ celery_utils/
 
 diff_cover: test
 	diff-cover coverage.xml

--- a/celery_utils/chordable_django_backend.py
+++ b/celery_utils/chordable_django_backend.py
@@ -1,0 +1,230 @@
+u"""
+An opt-in backend, designed to make using chords with the Django ORM easy.
+
+Additionally avoids the pooling unlock used by default in django-celery for
+performance benfits.
+
+Usage
+-----
+    First, import the needful from this module:
+        from celeryutils.chordable_django_backend import chord, chord_task
+
+    Then, change the task() decorators on your functions to the new chord_
+    decorators:
+        # Note that standard task options will be passed though!
+        @chord_task(max_retries=2, default_retry_delay=10)
+        def add(x, y):
+            return x + y
+
+        @chord_task()
+        def tsum(results):
+            _sum = 0
+            for num in results:
+                _sum = _sum + num
+            return _sum
+
+    Finally, call chord() as you normally would, and let ChordableDjangoBackend
+    take care of the rest:
+        chord(add.s(i, i) for i in xrange(10))(tsum.s())
+
+Notes
+-----
+    Please ensure that your callback function stores its results somewhere.
+    There is no "chord finished, come and get it!" signal, so having the
+    callback store the synthesized results of your parallel subtasks is
+    crucial.
+
+    By default, errors in the subtasks will prevent the callback from running.
+    Instead, the callback result will be set to FAILURE status and the result
+    will contain an exception detailing which subtasks errored. The other option
+    is <TODO FIGURE OUT THE DEV NOTE IN MODELS.PY AND PUT RESULTS HERE>, which
+    can be set with a False use_iterator option on your callback signature.
+
+    Similarly, the callback is, by default, called with an iterator of subtask
+    results. Since this cannot be serialized, it cannot be launched
+    asynchronously, and the final subtask will execute the callback in-process.
+    In order to disable this behavior (and build the results list in-memory),
+    set the propagate option on your callback signature to False.
+
+    To set either of the use_iterator or propagate options, add them to your
+    callback signature as follows:
+        c = chord(add.s(i, i) for i in xrange(10))
+        t = tsum.s()
+        t.options = {
+            'propagate': False,
+            'use_iterator': False
+        }
+        c(t)
+
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from copy import deepcopy
+from datetime import datetime, timedelta
+import json
+
+from celery import chord as _chord
+from celery import current_app, task
+from celery.states import FAILURE, SUCCESS
+from djcelery.backends.database import DatabaseBackend
+from djcelery.models import TaskMeta
+
+from django.db import transaction
+
+from celery_utils.models import ChordData
+
+
+class chord(_chord):  # pylint: disable=invalid-name
+    u"""
+    Overrides the default celery chord primitive to use this backend.
+    """
+
+    def __init__(self, *args, **kwargs):
+        u"""Super init, with a specialized 'app' kwarg."""
+        given_app = kwargs.pop(u'app', current_app)
+        kwargs[u'app'] = ChordableDjangoBackend.get_suitable_app(given_app)
+        super(chord, self).__init__(*args, **kwargs)
+
+
+def chord_task(*args, **kwargs):
+    u"""
+    Override of the default task decorator to specify use of this backend.
+    """
+    given_backend = kwargs.get(u'backend', None)
+    if not isinstance(given_backend, ChordableDjangoBackend):
+        kwargs[u'backend'] = ChordableDjangoBackend(kwargs.get('app', current_app))
+    return task(*args, **kwargs)
+
+
+class ChordableDjangoBackend(DatabaseBackend):
+    u"""
+    Extends djcelery.backends.database:DatabaseBackend to avoid polling.
+
+    See usage notes in module docstring before using.
+
+    Celery 4 upgrade notes
+    ----------------------
+        - django-celery (djcelery) is needed for ChordableDjangoBackend, and it's
+            incompatible with celery 4. Upon upgrading, we'll need to switch the
+            base class from djcelery.backends.database:DatabaseBackend to
+            django-celery-results.backends.database:DatabaseBackend
+    """
+
+    def _cleanup(self, status, expires_multiplier=1):
+        u"""
+        Clean up expired records.
+
+        Will remove all entries for any ChordData whose callback result is in
+        state <status> that was marked completed more than
+        (self.expires * <expires_multipler>) ago.
+        """
+        # self.expires is inherited, and defaults to 1 day (or setting CELERY_TASK_RESULT_EXPIRES)
+        expires = self.expires if isinstance(self.expires, timedelta) else timedelta(seconds=self.expires)
+        expires = expires * expires_multiplier
+        chords_to_delete = ChordData.objects.filter(
+            callback_result__date_done__lte=datetime.now() - expires,
+            callback_result__status=status
+        ).iterator()
+        for _chord in chords_to_delete:
+            subtask_ids = [subtask.task_id for subtask in _chord.completed_results.all()]
+            _chord.completed_results.clear()
+            TaskMeta.objects.filter(task_id__in=subtask_ids).delete()
+            _chord.callback_result.delete()
+            _chord.delete()
+
+    def cleanup(self):
+        u"""
+        Override default implementation of celery.task.backend_cleanup task.
+
+        We run this task on every callback execution, it could also easily be
+        run using a celery beat worker.
+        """
+        self._cleanup(SUCCESS)
+        self._cleanup(FAILURE, expires_multiplier=10)  # Let failed records stick around a bit longer
+
+    def add_to_chord(self, group_id, result):  # pragma: no cover
+        u"""
+        Deliberate override of abstract base method. We don't do anything here.
+        """
+        pass
+
+    def on_chord_part_return(self, task, state, result, propagate=False):  # pylint: disable=redefined-outer-name
+        u"""
+        Update the linking ChordData object and execute callback if needed.
+
+        Parameters
+        ----------
+            subtask: The subtask that just finished executing. Most useful values
+                are stored on subtask.request.
+            state: the status of the just-finished subtask.
+            result: the resulting value of subtask execution.
+            propagate: unused here, we check CELERY_CHORD_PROPAGATES and the
+                chord's options in chord_data.execute_callback()
+
+        """
+        with transaction.atomic():
+            chord_data = ChordData.objects.select_for_update().get(  # select_for_update will prevent race conditions
+                callback_result__task_id=task.request.chord[u'options'][u'task_id']
+            )
+            _ = TaskMeta.objects.update_or_create(
+                task_id=task.request.id,
+                defaults={
+                    u'status': state,
+                    u'result': result
+                }
+            )
+            if chord_data.is_ready():
+                # we don't use celery beat, so this is as good a place as any to fire off periodic cleanup tasks
+                self.get_suitable_app(current_app).tasks[u'celery.backend_cleanup'].apply_async()
+                chord_data.execute_callback()
+
+    def apply_chord(self, header, partial_args, group_id, body, **options):
+        u"""
+        Instantiate a linking ChordData object before executing subtasks.
+
+        Parameters
+        ----------
+            header: a list of incomplete subtask signatures, with partial
+                different-per-instance arguments already set.
+            partial_args: list of same-per-instance subtask arguments.
+            group_id: a uuid that proved unnecessary in our approach. We use
+                the callback's frozen TaskMeta id as a linking piece of data.
+            body: the callback task signature, with all non-subtask-dependent
+                arguments already set.
+
+        Return value is the (unfinished) AsyncResult for body.
+
+        """
+        callback_entry = TaskMeta.objects.create(task_id=body.id)
+        chord_data = ChordData.objects.create(callback_result=callback_entry)
+        for subtask in header:
+            subtask_entry = TaskMeta.objects.create(task_id=subtask.id)
+            chord_data.completed_results.add(subtask_entry)
+        if body.options.get(u'use_iterator', None) is None:
+            body.options[u'use_iterator'] = True
+        chord_data.serialized_callback = json.dumps(body)
+        chord_data.save()
+
+        return header(*partial_args, task_id=group_id)
+
+    def fallback_chord_unlock(self, group_id, body, result=None, countdown=1, **kwargs):  # pragma: no cover
+        u"""
+        Deliberate pass override.
+
+        The default django-celery DatabaseBackend will use this method to cry
+        havoc, and let slip the dogs of repeats-every-second polling. We do not
+        want that to happen, and so override the method to do nothing.
+        """
+        pass
+
+    @classmethod
+    def get_suitable_app(cls, given_app):
+        u"""
+        Return a clone of given_app with ChordableDjangoBackend, if needed.
+        """
+        if not isinstance(getattr(given_app, 'backend', None), ChordableDjangoBackend):
+            return_app = deepcopy(given_app)
+            return_app.backend = ChordableDjangoBackend(return_app)
+            return return_app
+        else:
+            return given_app

--- a/celery_utils/logged_task.py
+++ b/celery_utils/logged_task.py
@@ -20,7 +20,7 @@ class LoggedTask(Task):
 
     abstract = True
 
-    def apply_async(self, args=None, kwargs=None, **options):
+    def apply_async(self, args=None, kwargs=None, **options):  # pylint: disable=arguments-differ
         """
         Emit a log statement when the task is submitted.
         """

--- a/celery_utils/migrations/0002_chordable_django_backend.py
+++ b/celery_utils/migrations/0002_chordable_django_backend.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djcelery', '0001_initial'),
+        ('celery_utils', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ChordData',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('serialized_callback', models.TextField()),
+                ('callback_result', models.OneToOneField(related_name='chorddata_callback_result', to='djcelery.TaskMeta')),
+                ('completed_results', models.ManyToManyField(related_name='chorddata_sub_results', to='djcelery.TaskMeta')),
+            ],
+        ),
+    ]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,8 @@
 # Core requirements for using this application
 
-celery >= 3.1,<5.0
+celery >= 3.1,<4.0
 Django                    # Web application framework
+django-celery==3.2.1
 django-model-utils
+future
 jsonfield

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,12 +4,14 @@
 #
 #    pip-compile --output-file requirements/base.txt requirements/base.in
 #
-amqp==2.1.4               # via kombu
-billiard==3.5.0.2         # via celery
-celery==4.0.2
-django-model-utils==2.6.1
-Django==1.10.5            # via django-model-utils, jsonfield
-jsonfield==1.0.3
-kombu==4.0.2              # via celery
-pytz==2016.10             # via celery
-vine==1.1.3               # via amqp
+amqp==1.4.9               # via kombu
+anyjson==0.3.3            # via kombu
+billiard==3.3.0.23        # via celery
+celery==3.1.25
+django-celery==3.2.1
+django-model-utils==3.0.0
+Django==1.11.1            # via django-celery, django-model-utils, jsonfield
+future==0.16.0
+jsonfield==2.0.1
+kombu==3.0.37             # via celery
+pytz==2017.2              # via celery, django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,40 +4,42 @@
 #
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in requirements/quality.in
 #
-appdirs==1.4.0            # via setuptools
+appdirs==1.4.3            # via setuptools
 argparse==1.4.0           # via caniusepython3
 args==0.1.0               # via clint
-caniusepython3==4.0.0
+backports.functools-lru-cache==1.4  # via caniusepython3
+caniusepython3==5.0.0
 click==6.7                # via pip-tools
 clint==0.5.1              # via twine
-diff-cover==0.9.9
-distlib==0.2.4            # via caniusepython3
-django==1.10.5            # via edx-i18n-tools
+diff-cover==0.9.11
+distlib==0.2.5            # via caniusepython3
+django==1.10.7            # via edx-i18n-tools
 edx-i18n-tools==0.3.7
 first==2.0.1              # via pip-tools
-futures==3.0.5            # via caniusepython3
+futures==3.1.1            # via caniusepython3
 inflect==0.2.5            # via jinja2-pluralize
 isort==4.2.5
 jinja2-pluralize==0.3.0   # via diff-cover
-Jinja2==2.9.5             # via diff-cover, jinja2-pluralize
-MarkupSafe==0.23          # via jinja2
+Jinja2==2.9.6             # via diff-cover, jinja2-pluralize
+MarkupSafe==1.0           # via jinja2
 packaging==16.8           # via caniusepython3, setuptools
-path.py==10.1             # via edx-i18n-tools
-pip-tools==1.8.0
+path.py==10.3.1           # via edx-i18n-tools
+pip-tools==1.9.0
 pkginfo==1.4.1            # via twine
 pluggy==0.4.0             # via tox
 polib==1.0.8              # via edx-i18n-tools
-py==1.4.32                # via tox
+py==1.4.33                # via tox
 pycodestyle==2.3.1
-pydocstyle==1.1.1
+pydocstyle==2.0.0
 pygments==2.2.0           # via diff-cover
-pyparsing==2.1.10         # via packaging
+pyparsing==2.2.0          # via packaging
 pyYaml==3.12              # via edx-i18n-tools
-requests-toolbelt==0.7.0  # via twine
-requests==2.13.0          # via caniusepython3, requests-toolbelt, twine
-six==1.10.0               # via diff-cover, edx-i18n-tools, packaging, pip-tools, setuptools
-tox-battery==0.3
-tox==2.6.0
+requests-toolbelt==0.7.1  # via twine
+requests==2.14.2          # via caniusepython3, requests-toolbelt, twine
+six==1.10.0               # via diff-cover, edx-i18n-tools, packaging, pip-tools, pydocstyle, setuptools
+snowballstemmer==1.2.1    # via pydocstyle
+tox-battery==0.4
+tox==2.7.0
 twine==1.8.1
 virtualenv==15.1.0        # via tox
 wheel==0.29.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,34 +4,45 @@
 #
 #    pip-compile --output-file requirements/doc.txt requirements/base.in requirements/doc.in
 #
-alabaster==0.7.9          # via sphinx
-amqp==2.1.4               # via kombu
-babel==2.3.4              # via sphinx
-billiard==3.5.0.2         # via celery
-bleach==1.5.0             # via readme-renderer
-celery==4.0.2
-chardet==2.3.0            # via doc8
-django-model-utils==2.6.1
-Django==1.10.5            # via django-model-utils, jsonfield
-doc8==0.7.0
+alabaster==0.7.10         # via sphinx
+amqp==1.4.9               # via kombu
+anyjson==0.3.3            # via kombu
+appdirs==1.4.3            # via setuptools
+babel==2.4.0              # via sphinx
+billiard==3.3.0.23        # via celery
+bleach==2.0.0             # via readme-renderer
+celery==3.1.25
+chardet==3.0.3            # via doc8
+django-celery==3.2.1
+django-model-utils==3.0.0
+Django==1.11.1            # via django-celery, django-model-utils, jsonfield
+doc8==0.8.0
 docutils==0.13.1          # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.0.2
-html5lib==0.9999999       # via bleach
+future==0.16.0
+html5lib==0.999999999     # via bleach
 imagesize==0.7.1          # via sphinx
-Jinja2==2.9.5             # via sphinx
-jsonfield==1.0.3
-kombu==4.0.2              # via celery
-MarkupSafe==0.23          # via jinja2
-pbr==1.10.0               # via stevedore
-pockets==0.3.1            # via sphinxcontrib-napoleon
+Jinja2==2.9.6             # via sphinx
+jsonfield==2.0.1
+kombu==3.0.37             # via celery
+MarkupSafe==1.0           # via jinja2
+packaging==16.8           # via setuptools
+pbr==3.0.1                # via stevedore
+pockets==0.5.1            # via sphinxcontrib-napoleon
 Pygments==2.2.0           # via readme-renderer, sphinx
-pytz==2016.10             # via babel, celery
-readme-renderer==16.0
-requests==2.13.0          # via sphinx
-restructuredtext-lint==0.17.2  # via doc8
-six==1.10.0               # via bleach, doc8, edx-sphinx-theme, html5lib, pockets, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
+pyparsing==2.2.0          # via packaging
+pytz==2017.2              # via babel, celery, django
+readme-renderer==17.2
+requests==2.14.2          # via sphinx
+restructuredtext-lint==1.0.1  # via doc8
+six==1.10.0               # via bleach, doc8, edx-sphinx-theme, html5lib, packaging, pockets, readme-renderer, setuptools, sphinx, sphinxcontrib-napoleon, stevedore
 snowballstemmer==1.2.1    # via sphinx
-Sphinx==1.5.2             # via edx-sphinx-theme
-sphinxcontrib-napoleon==0.6.0
-stevedore==1.20.0         # via doc8
-vine==1.1.3               # via amqp
+Sphinx==1.6.1             # via edx-sphinx-theme
+sphinxcontrib-napoleon==0.6.1
+sphinxcontrib-websupport==1.0.1  # via sphinx
+stevedore==1.21.0         # via doc8
+typing==3.6.1             # via sphinx
+webencodings==0.5.1       # via html5lib
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools                # via html5lib, sphinx

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,21 +4,23 @@
 #
 #    pip-compile --output-file requirements/quality.txt requirements/quality.in
 #
-appdirs==1.4.0            # via setuptools
+appdirs==1.4.3            # via setuptools
 argparse==1.4.0           # via caniusepython3
-caniusepython3==4.0.0
-distlib==0.2.4            # via caniusepython3
-futures==3.0.5            # via caniusepython3
+backports.functools-lru-cache==1.4  # via caniusepython3
+caniusepython3==5.0.0
+distlib==0.2.5            # via caniusepython3
+futures==3.1.1            # via caniusepython3
 isort==4.2.5
 packaging==16.8           # via caniusepython3, setuptools
 pycodestyle==2.3.1
-pydocstyle==1.1.1
-pyparsing==2.1.10         # via packaging
-requests==2.13.0          # via caniusepython3
-six==1.10.0               # via packaging, setuptools
+pydocstyle==2.0.0
+pyparsing==2.2.0          # via packaging
+requests==2.14.2          # via caniusepython3
+six==1.10.0               # via packaging, pydocstyle, setuptools
+snowballstemmer==1.2.1    # via pydocstyle
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip                       # via caniusepython3
 # setuptools                # via caniusepython3
-pylint
-edx-lint                  # edX pylint rules and plugins
+pylint==1.6.4
+edx-lint==0.5.2                  # edX pylint rules and plugins

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,6 +2,7 @@
 
 
 ddt
+freezegun
 pytest-catchlog           # Show log output for test failures
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,26 +4,30 @@
 #
 #    pip-compile --output-file requirements/test.txt requirements/base.in requirements/test.in
 #
-amqp==2.1.4               # via kombu
-appdirs==1.4.0            # via setuptools
-billiard==3.5.0.2         # via celery
-celery==4.0.2
-coverage==4.3.4           # via pytest-cov
+amqp==1.4.9               # via kombu
+anyjson==0.3.3            # via kombu
+appdirs==1.4.3            # via setuptools
+billiard==3.3.0.23        # via celery
+celery==3.1.25
+coverage==4.4.1           # via pytest-cov
 ddt==1.1.1
-django-model-utils==2.6.1
-jsonfield==1.0.3
-kombu==4.0.2              # via celery
+django-celery==3.2.1
+django-model-utils==3.0.0
+freezegun==0.3.9
+future==0.16.0
+jsonfield==2.0.1
+kombu==3.0.37             # via celery
 packaging==16.8           # via setuptools
-py==1.4.32                # via pytest, pytest-catchlog
-pyparsing==2.1.10         # via packaging
+py==1.4.33                # via pytest, pytest-catchlog
+pyparsing==2.2.0          # via packaging
 pytest-catchlog==1.2.2
-pytest-cov==2.4.0
+pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.0.6             # via pytest-catchlog, pytest-cov, pytest-django
+pytest==3.0.7             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.6.0    # via freezegun
 python-memcached==1.58
-pytz==2016.10             # via celery
-six==1.10.0               # via packaging, python-memcached, setuptools
-vine==1.1.3               # via amqp
+pytz==2017.2              # via celery, django
+six==1.10.0               # via freezegun, packaging, python-dateutil, python-memcached, setuptools
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via pytest

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,12 +4,11 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
-argparse==1.4.0           # via codecov
-codecov==2.0.5
-coverage==4.3.4           # via codecov
+codecov==2.0.9
+coverage==4.4.1           # via codecov
 pluggy==0.4.0             # via tox
-py==1.4.32                # via tox
-requests==2.13.0          # via codecov
-tox-battery==0.3
-tox==2.6.0
+py==1.4.33                # via tox
+requests==2.14.2          # via codecov
+tox-battery==0.4
+tox==2.7.0
 virtualenv==15.1.0        # via tox

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "celery>=3.1,<5.0",
+        "celery>=3.1.25,<4.0",
         "Django>=1.8,<1.11",
         "django-model-utils",
         "jsonfield",

--- a/test_settings.py
+++ b/test_settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.sessions',
     'django.contrib.staticfiles',
+    'djcelery',
     'celery_utils',
     'test_utils',
 )

--- a/tests/test_chordable_django_backend.py
+++ b/tests/test_chordable_django_backend.py
@@ -1,0 +1,232 @@
+"""
+Test ChordableDjangoBackend.
+
+A lot of the intended usage of this backend happens asychronously, which is
+notoriously hard to test. Please do extensive testing for your situation before
+relying on async behavior, as these tests only ensure correctness in a single
+threaded process.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from builtins import range as _range
+from datetime import datetime, timedelta
+
+from celery import current_app
+from celery.exceptions import ChordError
+from celery.states import FAILURE, PENDING, SUCCESS
+from djcelery.models import TaskMeta
+from freezegun import freeze_time
+from mock import MagicMock, patch
+import pytest
+
+from django.test import override_settings
+
+from celery_utils.chordable_django_backend import ChordableDjangoBackend, chord, chord_task
+from celery_utils.models import ChordData
+
+
+@chord_task()
+def chord_subtask(i):
+    """
+    Toy example of a subtask.
+    """
+    return i + i
+
+
+@chord_task()
+def chord_callback(results):
+    """
+    Toy example of a callback.
+    """
+    return sum([result for result in results])
+
+
+@chord_task()
+def chord_callback_itr(results_itr):
+    """
+    Toy example of a callback that accepts an iterator.
+    """
+    return sum(result for result in results_itr())
+
+
+@chord_task()
+def chord_callback_no_itr(results):
+    """
+    Toy example of a callback that does not accept an iterator.
+    """
+    return sum(results)
+
+
+@chord_task()
+def chord_callback_error(results):  # pylint: disable=unused-argument
+    """
+    Toy example of a callback that raises an error.
+    """
+    raise NotImplementedError('Nothing was ever implemented in this task :(')
+
+
+def test_overrides():
+    """
+    Test to ensure ChordableDjangoBackend promitives override as expected.
+    """
+    @chord_task()
+    def inner_task1(*args):  # pylint: disable=missing-docstring, unused-argument
+        pass
+
+    @chord_task(backend=current_app.backend)
+    def inner_task2(*args):  # pylint: disable=missing-docstring, unused-argument
+        pass
+
+    @chord_task(backend=ChordableDjangoBackend(current_app))
+    def inner_task3(*args):  # pylint: disable=missing-docstring, unused-argument
+        pass
+
+    test_chord1 = chord(inner_task1(i) for i in _range(10))
+    test_chord2 = chord((inner_task2(i) for i in _range(10)), app=current_app)
+    test_chord3 = chord(
+        (inner_task3(i) for i in _range(10)),
+        app=ChordableDjangoBackend.get_suitable_app(current_app)
+    )
+
+    assert isinstance(inner_task1.backend, ChordableDjangoBackend)
+    assert isinstance(inner_task2.backend, ChordableDjangoBackend)
+    assert isinstance(inner_task3.backend, ChordableDjangoBackend)
+
+    assert isinstance(test_chord1.app.backend, ChordableDjangoBackend)
+    assert isinstance(test_chord2.app.backend, ChordableDjangoBackend)
+    assert isinstance(test_chord3.app.backend, ChordableDjangoBackend)
+
+
+def test_simple_chord():
+    """
+    Test full chord execution in eager mode, check result.
+    """
+    test_chord = chord(chord_subtask.s(i) for i in _range(10))(chord_callback.s())
+
+    # [0, 1, ..., 9] + [0, 1, ..., 9] = [0, 2, 4, 6, 8, 12, 14, 16, 18]
+    # 2+4+6+8+10+12+14+16+18 = 90
+    assert test_chord.result == 90
+
+
+@pytest.mark.django_db
+@override_settings(CELERY_ALWAYS_EAGER=False)
+def test_chord_itr():
+    """
+    Test a standard chord with default options.
+    """
+    chord_data = _test_chord_internal(chord_callback_itr.s())
+    assert chord_data.callback_result.status == SUCCESS
+    assert chord_data.callback_result.result is None
+
+
+@pytest.mark.django_db
+@override_settings(CELERY_ALWAYS_EAGER=False)
+def test_chord_no_itr():
+    """
+    Test a standard chord with the use_iterator callback option set to False.
+    """
+    with patch('celery.app.task.Task.apply_async') as mock_apply_async:
+        callback = chord_callback_no_itr.s()
+        callback.options = {'use_iterator': False}
+        chord_data = _test_chord_internal(callback)
+
+        # since we've overriden CELERY_ALWAYS_EAGER, the callback will not be run synchronously
+        # however, since there are no workers, it also will not be run asynchronously
+        assert chord_data.callback_result.status == PENDING
+        assert mock_apply_async.called
+
+
+@pytest.mark.django_db
+@override_settings(CELERY_ALWAYS_EAGER=False, CELERY_CHORD_PROPAGATES=True)
+def test_failing_chord_propagate():
+    """
+    Test a chord with failing subtasks and propagation.
+    """
+    chord_data = _test_chord_internal(chord_callback_itr.s(), failing_subtasks=True)
+
+    assert chord_data.callback_result.status == FAILURE
+    assert isinstance(chord_data.callback_result.result, ChordError)
+    assert len(chord_data.callback_result.traceback) > 0
+
+
+@pytest.mark.django_db
+@override_settings(CELERY_ALWAYS_EAGER=False, CELERY_CHORD_PROPAGATES=True)
+def test_failing_chord_no_propagate():
+    """
+    Test a chord with failing subtasks and propagation.
+    """
+    callback = chord_callback_itr.s()
+    callback.options = {'propagate': False}
+    chord_data = _test_chord_internal(callback, failing_subtasks=True)
+
+    assert chord_data.callback_result.result is None
+    # 6 subtasks, as indices 0, 3, 6, and 9 were dropped
+    assert "depends on 6 subtasks, status SUCCESS" in str(chord_data)
+
+
+@pytest.mark.django_db
+@override_settings(CELERY_ALWAYS_EAGER=False)
+def test_callback_error():
+    chord_data = _test_chord_internal(chord_callback_error.s())
+
+    assert chord_data.callback_result.status == FAILURE
+    assert isinstance(chord_data.callback_result.result, NotImplementedError)
+    assert len(chord_data.callback_result.traceback) > 0
+    assert chord_data.completed_results.filter(status=SUCCESS).count() == 10
+
+
+def _test_chord_internal(callback_signature, failing_subtasks=False):
+    """
+    "Run" a chord in non-eager mode by mocking a bunch of things out.
+    """
+    # Notice that we don't specify an app kwargs here, the 'chord' override will handle things
+    test_chord = chord(chord_subtask.s(i) for i in _range(10))(callback_signature)
+
+    # We now have several "tasks queued for execution" that will never be executed.
+    assert TaskMeta.objects.all().count() == 11  # 10 subtasks, 1 callback
+
+    chord_data = ChordData.objects.filter(callback_result__task_id=test_chord.id).first()
+    for i, subtask in enumerate(chord_data.completed_results.all()):
+        subtask.status = FAILURE if i % 3 == 0 and failing_subtasks else SUCCESS
+        subtask.request = MagicMock(id=subtask.task_id, chord={'options': {'task_id': test_chord.id}})
+        chord_subtask.backend.on_chord_part_return(subtask, subtask.status, -2)
+
+    return chord_data
+
+
+@pytest.mark.django_db
+@override_settings(CELERY_ALWAYS_EAGER=False)
+def test_cleanup_success():
+    """
+    Test backend cleanup of successful ChordData usage.
+    """
+    _test_cleanup()
+
+
+@pytest.mark.django_db
+@override_settings(CELERY_ALWAYS_EAGER=False)
+def test_cleanup_failure():
+    """
+    Test backend cleanup of failure ChordData usage.
+    """
+    _test_cleanup(failures=True)
+
+
+def _test_cleanup(failures=False):
+    """
+    Validate that the celery.backend_cleanup task calls our backend.
+    """
+    _test_chord_internal(chord_callback_itr.s(), failing_subtasks=failures)
+    cleanup = ChordableDjangoBackend.get_suitable_app(current_app).tasks['celery.backend_cleanup']
+
+    with freeze_time(datetime.now() + timedelta(days=8)):
+        cleanup.apply()
+    assert TaskMeta.objects.all().count() == (11 if failures else 0)
+    assert ChordData.objects.all().count() == (1 if failures else 0)
+
+    # after 70 days we'll clean up failures too
+    with freeze_time(datetime.now() + timedelta(days=71)):
+        cleanup.apply()
+    assert TaskMeta.objects.all().count() == 0
+    assert ChordData.objects.all().count() == 0

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,7 @@ deps =
     django110: Django>=1.10,<1.11
 commands =
      celery3: pip install -U celery>=3.1.25,<4.0
-     celery4: pip install -U celery>=4.0.2,<5.0
-     py.test {posargs}
+     py.test tests/ celery_utils/ {posargs}
 
 [testenv:docs]
 setenv =


### PR DESCRIPTION
As stated in the name, trying to create a backend that combines the best aspects of several other backend types that weirdly don't work for us for one reason or another. The goal here is to:

- use a django db to store task results
- allow chords to be used without the busy polling we get out of the box

If this works really well, we can try to get it upstream to either [django-celery](https://github.com/celery/django-celery/blob/216e173687326ef05a8a0d2feda8f51ffd11ba5d/djcelery/backends/database.py#L10) or [django-celery-results](https://github.com/celery/django-celery-results/blob/master/django_celery_results/backends/database.py#L10), depending on which version of celery we're using at that point (3.x for the former, 4.x for the latter).

FYI @edx/educator-neem 