### PR TITLE
Migration Magic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	cat requirements/quality-extra.txt >> requirements/quality.txt
 	cat requirements/test-extra.txt >> requirements/test.txt
 	# Let tox control the Django version for tests
-	sed '/Django==/d' requirements/test.txt > requirements/test.tmp
+	sed '/^[Dd]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
 
 quality: ## check coding style with pycodestyle and pylint

--- a/celery_utils/migrations/0002_djcelery_cleanup.py
+++ b/celery_utils/migrations/0002_djcelery_cleanup.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.core import management
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    """
+    A dirty, dirty hack to clean up the unused (for us) djcelery tables.
+    """
+    if not Migration.DIRTY_HACK_CONSTANT:
+        Migration.DIRTY_HACK_CONSTANT = True
+        management.call_command('migrate', 'djcelery', '--fake-initial')
+        management.call_command('migrate', 'djcelery', 'zero')
+
+
+class Migration(migrations.Migration):
+
+    DIRTY_HACK_CONSTANT = False
+    dependencies = [
+        ('celery_utils', '0001_initial'),
+    ]
+
+    run_before = [
+        ('djcelery', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, reverse_code=migrations.RunPython.noop),
+    ]

--- a/celery_utils/migrations/0003_chordable_django_backend.py
+++ b/celery_utils/migrations/0003_chordable_django_backend.py
@@ -7,8 +7,8 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('celery_utils', '0002_djcelery_cleanup'),
         ('djcelery', '0001_initial'),
-        ('celery_utils', '0001_initial'),
     ]
 
     operations = [

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,9 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        "celery>=3.1.25,<4.0",
+        "celery>=3.1,<4.0",
         "Django>=1.8,<1.11",
+        "django-celery>=3.2.1",
         "django-model-utils",
         "jsonfield",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
 commands =
-     celery3: pip install -U celery>=3.1.25,<4.0
+     celery3: pip install -U celery>=3.1,<4.0
      py.test tests/ celery_utils/ {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
Possible fix for our migration woes.

Changes:
- move migration 0002 to be 0003, since it hasn't yet been applied anywhere
- create new migration 0002, which will:
  - be run *before* any django-celery migrations, due to use of the [`run_before` attribute](https://docs.djangoproject.com/en/1.8/howto/writing-migrations/#controlling-the-order-of-migrations).
  - fake said migration, then zero the app to drop the problematic tables via `management.call_command('migrate', 'djcelery', '--fake-initial')` and `management.call_command('migrate', 'djcelery', 'zero')`