### PR TITLE
Add drop_djcelery_tables management command

### DIFF
--- a/celery_utils/logged_task.py
+++ b/celery_utils/logged_task.py
@@ -8,7 +8,6 @@ import logging
 
 from celery import Task
 
-
 log = logging.getLogger(__name__)
 
 

--- a/celery_utils/management/commands/drop_djcelery_tables.py
+++ b/celery_utils/management/commands/drop_djcelery_tables.py
@@ -1,0 +1,80 @@
+"""
+This command will drop the tables included in django-celery's
+migrations, which are included when we bump that to 3.2.1
+
+If the tables are not empty, this command will show a message and exit.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import OrderedDict
+import logging
+from textwrap import dedent
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+from djcelery.models import (CrontabSchedule, IntervalSchedule, PeriodicTask,  # pylint:disable=import-error
+                             PeriodicTasks, TaskMeta, TaskSetMeta, TaskState, WorkerState)
+
+log = logging.getLogger(__name__)
+
+DJCELERY_MODEL_TABLES = OrderedDict({
+    PeriodicTask: '\"djcelery_periodictask\"',  # must be before crontab, interval
+    TaskState: '\"djcelery_taskstate\"',  # must be before workerstate
+})
+DJCELERY_MODEL_TABLES.update({
+    CrontabSchedule: '\"djcelery_crontabschedule\"',
+    IntervalSchedule: '\"djcelery_intervalschedule\"',
+    PeriodicTasks: '\"djcelery_periodictasks\"',
+    WorkerState: '\"djcelery_workerstate\"',
+    TaskSetMeta: '\"celery_tasksetmeta\"',
+    TaskMeta: '\"celery_taskmeta\"',
+})
+
+
+class Command(BaseCommand):
+    """
+    Drop the database tables used by django-celery, iff they are empty.
+    """
+    help = dedent(__doc__).strip()
+
+    def _log_execute(self, cursor, sql, context=""):
+        """
+        Log a given SQL input (as string) before executing it.
+        """
+        log.info("{} raw SQL:\n{}".format(context, sql))
+        cursor.execute(sql)
+
+    def handle(self, *args, **options):
+        with connection.cursor() as cursor:
+            try:
+                log.info("Acquiring tables locks on {}".format(", ".join(DJCELERY_MODEL_TABLES.values())))
+                lock_sql = "LOCK TABLES {}".format(
+                    ", ".join(
+                        "{} WRITE".format(table)
+                        for table in DJCELERY_MODEL_TABLES.values()
+                    )
+                )
+                self._log_execute(cursor, lock_sql, 'table lock')
+
+                for model in DJCELERY_MODEL_TABLES.keys():
+                    assert model.objects.all().count() == 0
+                log.info("Tables are confirmed empty and I hold a lock on all of them, proceeding to DROP TABLE")
+
+                for table_name in DJCELERY_MODEL_TABLES.values():
+                    drop_sql = "DROP TABLE IF EXISTS {} CASCADE".format(table_name)
+                    self._log_execute(cursor, drop_sql, "drop {}".format(table_name))
+                log.info("Tables have been dropped, proceed with djcelery migrations as needed.")
+            except AssertionError:
+                output = (
+                    "The tables associated with django-celery are in use and non-empty.\n"
+                    "This presents a problem for edx-celeryutils, as we need to upgrade"
+                    "the installed version of django-celery, and the newer version uses"
+                    "migrations where the previous version used sync_db.\nYou, dear user,"
+                    "have won the special prize of being a corner case we at edx.org were"
+                    "not aware of.\nPlease try to rectify the djcelery tables on your own,"
+                    "using --skip-initial or other methods as needed. If you do not, the"
+                    "next release of edx-celeryutils will try perform django-celery's"
+                    "initial migration and fail with a 'table already exists' error."
+                )
+                log.info(output)

--- a/celery_utils/management/commands/drop_djcelery_tables.py
+++ b/celery_utils/management/commands/drop_djcelery_tables.py
@@ -10,11 +10,11 @@ from collections import OrderedDict
 import logging
 from textwrap import dedent
 
-from django.core.management.base import BaseCommand
-from django.db import connection
-
 from djcelery.models import (CrontabSchedule, IntervalSchedule, PeriodicTask,  # pylint:disable=import-error
                              PeriodicTasks, TaskMeta, TaskSetMeta, TaskState, WorkerState)
+
+from django.core.management.base import BaseCommand
+from django.db import connection
 
 log = logging.getLogger(__name__)
 

--- a/celery_utils/migrations/0001_initial.py
+++ b/celery_utils/migrations/0001_initial.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.utils.timezone
+
 import jsonfield.fields
 import model_utils.fields
 

--- a/celery_utils/tasks.py
+++ b/celery_utils/tasks.py
@@ -5,6 +5,7 @@ Celery tasks that support the utils in this module.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from celery import shared_task
+
 from django.utils.timezone import now
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,6 @@ coverage:
         target: 100%
 
 comment: false
+
+ignore:
+ - "celery_utils/management/commands/drop_djcelery_tables.py"

--- a/test_utils/celery.py
+++ b/test_utils/celery.py
@@ -8,7 +8,6 @@ import os
 
 from celery import Celery
 
-
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_settings')
 

--- a/tests/test_persist_on_failure.py
+++ b/tests/test_persist_on_failure.py
@@ -12,7 +12,6 @@ import pytest
 import six
 
 from celery_utils.models import FailedTask
-
 from test_utils import tasks
 
 


### PR DESCRIPTION
Okay, I think I've figured things out here. https://github.com/edx/edx-celeryutils/pull/8 is a branch made off edx-celeryutils version `0.1.3`, but the github UI only allows for a PR against master. That discrepancy explains why the two CI builds disagree on that PR.

I think the plan forward will involve this change existing on 2 branches:
- we *don't* merge #8, but I *do* create a tag `0.1.4`, targeting that branch's HEAD.
  - said `0.1.4` tag gets merged into edx-platform ASAP, so we can get this command without the unwanted additions made in `0.2.0` and following.
- This PR, containing the exact same commit rebase onto master (at the current version `0.2.1`) *will* be merged in this repo
- Then I create another release, `0.2.2`, and include that in the "merge everything" PR, https://github.com/edx/edx-platform/pull/15167

Does that seem accurate @macdiesel @jibsheet?