### PR TITLE
Add Django 1.11 testing to tox suite.

### DIFF
--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -5,6 +5,6 @@ Code to support working with celery.
 from __future__ import absolute_import, unicode_literals
 
 
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "celery>=3.1.25,<4.0",
-        "Django>=1.8,<1.11",
+        "Django>=1.8,<2.0",
         "django-model-utils",
         "jsonfield",
     ],
@@ -61,6 +61,7 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py27}-django{18,19,110}-celery3,py27-django{18,19,110}-celery3
+envlist = {py35,py27}-django{18,19,110,111}
 
 [doc8]
 max-line-length = 120
@@ -28,6 +28,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
 commands =
      celery3: pip install -U celery>=3.1.25,<4.0
      py.test tests/ celery_utils/ {posargs}


### PR DESCRIPTION
The Django app already supports Django 1.11 - just adding tox testing for it in this PR.