### PR TITLE
Upgrade django-celery version.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Change Log
 ----------
 
 ..
-   All enhancements and patches to cookiecutter-django-app will be documented
+   All enhancements and patches to edx-celeryutils will be documented
    in this file.  It adheres to the structure of http://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
@@ -17,6 +17,31 @@ Unreleased
 
 Added
 _____
+
+[0.2.6] - 2017-08-07
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Upgrade version of django-celery.
+
+[0.2.5] - 2017-08-03
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Django 1.11 compatibility
+
+[0.2.4] - 2017-06-20
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add management command to fix djcelery tables.
+
+[0.2.1] - 2017-05-22
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add ChordableDjangoBackend and testing.
+
+[0.1.3] - 2017-03-01
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Packaging changes.
 
 [0.1.1] - 2017-02-22
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -5,6 +5,6 @@ Code to support working with celery.
 from __future__ import absolute_import, unicode_literals
 
 
-__version__ = '0.2.5'
+__version__ = '0.2.6'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,9 @@
 
 celery >= 3.1,<4.0
 Django                    # Web application framework
-django-celery==3.2.1
+# Why a django-celery fork? To add Django 1.11 compatibility to the abandoned django-celery repo.
+# This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
+-e git+https://github.com/edx/django-celery.git@f87c6f914a1410463f54aebf68458c0653b20602#egg=django-celery==3.2.1+edx.1
 django-model-utils
 future
 jsonfield

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,14 +4,14 @@
 #
 #    pip-compile --output-file requirements/base.txt requirements/base.in
 #
+-e git+https://github.com/edx/django-celery.git@f87c6f914a1410463f54aebf68458c0653b20602#egg=django-celery==3.2.1+edx.1
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.25
-django-celery==3.2.1
 django-model-utils==3.0.0
-Django==1.11.1            # via django-celery, django-model-utils, jsonfield
+django==1.11.4            # via django-model-utils, jsonfield
 future==0.16.0
-jsonfield==2.0.1
+jsonfield==2.0.2
 kombu==3.0.37             # via celery
 pytz==2017.2              # via celery, django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,47 +4,46 @@
 #
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in requirements/quality.in
 #
-appdirs==1.4.3            # via setuptools
 argparse==1.4.0           # via caniusepython3
-args==0.1.0               # via clint
 backports.functools-lru-cache==1.4  # via caniusepython3
 caniusepython3==5.0.0
+certifi==2017.7.27.1      # via requests
+chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
-clint==0.5.1              # via twine
-diff-cover==0.9.11
+diff-cover==0.9.12
 distlib==0.2.5            # via caniusepython3
-django==1.10.7            # via edx-i18n-tools
-edx-i18n-tools==0.3.7
+django==1.11.4            # via edx-i18n-tools
+edx-i18n-tools==0.3.9
 first==2.0.1              # via pip-tools
 futures==3.1.1            # via caniusepython3
+idna==2.5                 # via requests
 inflect==0.2.5            # via jinja2-pluralize
-isort==4.2.5
+isort==4.2.15
 jinja2-pluralize==0.3.0   # via diff-cover
-Jinja2==2.9.6             # via diff-cover, jinja2-pluralize
-MarkupSafe==1.0           # via jinja2
-packaging==16.8           # via caniusepython3, setuptools
+jinja2==2.9.6             # via diff-cover, jinja2-pluralize
+markupsafe==1.0           # via jinja2
+packaging==16.8           # via caniusepython3
 path.py==10.3.1           # via edx-i18n-tools
 pip-tools==1.9.0
 pkginfo==1.4.1            # via twine
 pluggy==0.4.0             # via tox
 polib==1.0.8              # via edx-i18n-tools
-py==1.4.33                # via tox
+py==1.4.34                # via tox
 pycodestyle==2.3.1
 pydocstyle==2.0.0
 pygments==2.2.0           # via diff-cover
 pyparsing==2.2.0          # via packaging
-pyYaml==3.12              # via edx-i18n-tools
-requests-toolbelt==0.7.1  # via twine
-requests==2.14.2          # via caniusepython3, requests-toolbelt, twine
-six==1.10.0               # via diff-cover, edx-i18n-tools, packaging, pip-tools, pydocstyle, setuptools
+pytz==2017.2              # via django
+pyyaml==3.12              # via edx-i18n-tools
+requests-toolbelt==0.8.0  # via twine
+requests==2.18.3          # via caniusepython3, requests-toolbelt, twine
+six==1.10.0               # via diff-cover, edx-i18n-tools, packaging, pip-tools, pydocstyle
 snowballstemmer==1.2.1    # via pydocstyle
 tox-battery==0.4
 tox==2.7.0
-twine==1.8.1
+tqdm==4.15.0              # via twine
+twine==1.9.1
+urllib3==1.22             # via requests
 virtualenv==15.1.0        # via tox
 wheel==0.29.0
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip                       # via caniusepython3
-# setuptools                # via caniusepython3, twine
 edx-lint                  # For updating pylintrc

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,45 +4,42 @@
 #
 #    pip-compile --output-file requirements/doc.txt requirements/base.in requirements/doc.in
 #
+-e git+https://github.com/edx/django-celery.git@f87c6f914a1410463f54aebf68458c0653b20602#egg=django-celery==3.2.1+edx.1
 alabaster==0.7.10         # via sphinx
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-appdirs==1.4.3            # via setuptools
 babel==2.4.0              # via sphinx
 billiard==3.3.0.23        # via celery
 bleach==2.0.0             # via readme-renderer
 celery==3.1.25
-chardet==3.0.3            # via doc8
-django-celery==3.2.1
+certifi==2017.7.27.1      # via requests
+chardet==3.0.4            # via doc8, requests
 django-model-utils==3.0.0
-Django==1.11.1            # via django-celery, django-model-utils, jsonfield
+django==1.11.4            # via django-model-utils, jsonfield
 doc8==0.8.0
-docutils==0.13.1          # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-sphinx-theme==1.0.2
+docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
+edx-sphinx-theme==1.2.0
 future==0.16.0
 html5lib==0.999999999     # via bleach
+idna==2.5                 # via requests
 imagesize==0.7.1          # via sphinx
-Jinja2==2.9.6             # via sphinx
-jsonfield==2.0.1
+jinja2==2.9.6             # via sphinx
+jsonfield==2.0.2
 kombu==3.0.37             # via celery
-MarkupSafe==1.0           # via jinja2
-packaging==16.8           # via setuptools
-pbr==3.0.1                # via stevedore
+markupsafe==1.0           # via jinja2
+pbr==3.1.1                # via stevedore
 pockets==0.5.1            # via sphinxcontrib-napoleon
-Pygments==2.2.0           # via readme-renderer, sphinx
-pyparsing==2.2.0          # via packaging
+pygments==2.2.0           # via readme-renderer, sphinx
 pytz==2017.2              # via babel, celery, django
 readme-renderer==17.2
-requests==2.14.2          # via sphinx
-restructuredtext-lint==1.0.1  # via doc8
-six==1.10.0               # via bleach, doc8, edx-sphinx-theme, html5lib, packaging, pockets, readme-renderer, setuptools, sphinx, sphinxcontrib-napoleon, stevedore
+requests==2.18.3          # via sphinx
+restructuredtext-lint==1.1.1  # via doc8
+six==1.10.0               # via bleach, doc8, edx-sphinx-theme, html5lib, pockets, readme-renderer, sphinx, sphinxcontrib-napoleon, stevedore
 snowballstemmer==1.2.1    # via sphinx
-Sphinx==1.6.1             # via edx-sphinx-theme
+sphinx==1.6.3             # via edx-sphinx-theme
 sphinxcontrib-napoleon==0.6.1
 sphinxcontrib-websupport==1.0.1  # via sphinx
-stevedore==1.21.0         # via doc8
+stevedore==1.25.0         # via doc8
 typing==3.6.1             # via sphinx
+urllib3==1.22             # via requests
 webencodings==0.5.1       # via html5lib
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools                # via html5lib, sphinx

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,23 +4,22 @@
 #
 #    pip-compile --output-file requirements/quality.txt requirements/quality.in
 #
-appdirs==1.4.3            # via setuptools
 argparse==1.4.0           # via caniusepython3
 backports.functools-lru-cache==1.4  # via caniusepython3
 caniusepython3==5.0.0
+certifi==2017.7.27.1      # via requests
+chardet==3.0.4            # via requests
 distlib==0.2.5            # via caniusepython3
 futures==3.1.1            # via caniusepython3
-isort==4.2.5
-packaging==16.8           # via caniusepython3, setuptools
+idna==2.5                 # via requests
+isort==4.2.15
+packaging==16.8           # via caniusepython3
 pycodestyle==2.3.1
 pydocstyle==2.0.0
 pyparsing==2.2.0          # via packaging
-requests==2.14.2          # via caniusepython3
-six==1.10.0               # via packaging, pydocstyle, setuptools
+requests==2.18.3          # via caniusepython3
+six==1.10.0               # via packaging, pydocstyle
 snowballstemmer==1.2.1    # via pydocstyle
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip                       # via caniusepython3
-# setuptools                # via caniusepython3
+urllib3==1.22             # via requests
 pylint==1.6.4
 edx-lint==0.5.2                  # edX pylint rules and plugins

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,31 +4,25 @@
 #
 #    pip-compile --output-file requirements/test.txt requirements/base.in requirements/test.in
 #
+-e git+https://github.com/edx/django-celery.git@f87c6f914a1410463f54aebf68458c0653b20602#egg=django-celery==3.2.1+edx.1
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
-appdirs==1.4.3            # via setuptools
 billiard==3.3.0.23        # via celery
 celery==3.1.25
 coverage==4.4.1           # via pytest-cov
 ddt==1.1.1
-django-celery==3.2.1
 django-model-utils==3.0.0
 freezegun==0.3.9
 future==0.16.0
-jsonfield==2.0.1
+jsonfield==2.0.2
 kombu==3.0.37             # via celery
-packaging==16.8           # via setuptools
-py==1.4.33                # via pytest, pytest-catchlog
-pyparsing==2.2.0          # via packaging
+py==1.4.34                # via pytest, pytest-catchlog
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest==3.0.7             # via pytest-catchlog, pytest-cov, pytest-django
-python-dateutil==2.6.0    # via freezegun
+pytest==3.2.0             # via pytest-catchlog, pytest-cov, pytest-django
+python-dateutil==2.6.1    # via freezegun
 python-memcached==1.58
 pytz==2017.2              # via celery, django
-six==1.10.0               # via freezegun, packaging, python-dateutil, python-memcached, setuptools
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools                # via pytest
+six==1.10.0               # via freezegun, python-dateutil, python-memcached
 mock

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,11 +4,15 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
+certifi==2017.7.27.1      # via requests
+chardet==3.0.4            # via requests
 codecov==2.0.9
 coverage==4.4.1           # via codecov
+idna==2.5                 # via requests
 pluggy==0.4.0             # via tox
-py==1.4.33                # via tox
-requests==2.14.2          # via codecov
+py==1.4.34                # via tox
+requests==2.18.3          # via codecov
 tox-battery==0.4
 tox==2.7.0
+urllib3==1.22             # via requests
 virtualenv==15.1.0        # via tox


### PR DESCRIPTION
We've moved to an edX fork of django-celery until the Celery 4 upgrade occurs.