### PR TITLE
Add failure logging to LoggedTask

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 J. Cliff Dyer <cdyer@edx.org>
 Eric Fischer <efischer@edx.org>
+Gabe Mulley <gabe@edx.org>

--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -5,6 +5,6 @@ Code to support working with celery.
 from __future__ import absolute_import, unicode_literals
 
 
-__version__ = '0.2.6'
+__version__ = '0.2.7'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/celery_utils/logged_task.py
+++ b/celery_utils/logged_task.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 # pylint: disable=abstract-method
 class LoggedTask(Task):
     """
-    Task base class that emits a log statement when it gets submitted.
+    Task base class that emits a log statement when it gets submitted, retried or fails.
     """
 
     abstract = True
@@ -36,6 +36,14 @@ class LoggedTask(Task):
         """
         Capture the exception that caused the task to be retried, if any.
         """
-        super(LoggedTask, self).on_retry(exc, task_id, args, kwargs, einfo)
         if exc is not None:
             log.warning('[{}] retried due to {}'.format(task_id, einfo.traceback))
+        super(LoggedTask, self).on_retry(exc, task_id, args, kwargs, einfo)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        """
+        Capture the exception that caused the task to fail, if any.
+        """
+        if exc is not None:
+            log.warning('[{}] failed due to {}'.format(task_id, einfo.traceback))
+        super(LoggedTask, self).on_failure(exc, task_id, args, kwargs, einfo)

--- a/test_utils/tasks.py
+++ b/test_utils/tasks.py
@@ -32,3 +32,11 @@ def simple_logged_task(a, b, c):  # pylint: disable=invalid-name
     This task gets logged
     """
     return a + b + c
+
+@app.task(base=logged_task.LoggedTask)
+def failing_logged_task():
+    """
+    This task always fails.
+    """
+    # This will raise a ValueError
+    return int("foo")

--- a/tests/test_logged_task.py
+++ b/tests/test_logged_task.py
@@ -57,3 +57,14 @@ def test_no_capture_on_retry_unless_exception():
     with mock.patch('celery_utils.logged_task.log') as mocklog:
         task.on_retry(exc, task_id, args, kwargs, einfo)
         assert not mocklog.warning.called
+
+
+def test_on_failure_formatting():
+    with mock.patch('celery_utils.logged_task.log') as mocklog:
+        result = tasks.failing_logged_task.apply_async()
+        try:
+            result.wait()
+        except ValueError:
+            pass
+        logmessage = mocklog.warning.call_args[0][0]
+        assert 'ValueError' in logmessage


### PR DESCRIPTION
The @edx/rapid-experiments-team is looking to use this base class for one of our tasks, however, our tasks are not retryable (at-most-once). However, we would like to capture any exceptions raised during processing in the log.

I don't know how many new log entries this will create, I'm hoping/assuming our tasks don't fail very often.