### PR TITLE
Django2: upgrade django-model-utils

### DIFF
--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -4,6 +4,6 @@ Code to support working with celery.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,7 +3,7 @@
 -c constraints.txt
 
 future
-celery>= 3.1.25,<4.0	
+celery>= 3.1.25,<4.0
 Django >= 1.11 , <2.3
-django-model-utils==3.0.0	
+django-model-utils
 jsonfield2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 celery==3.1.26.post2      # via -r requirements/base.in
-django-model-utils==3.0.0  # via -r requirements/base.in
+django-model-utils==3.2.0  # via -r requirements/base.in
 django==2.2.11            # via -r requirements/base.in, django-model-utils, jsonfield2
 future==0.18.2            # via -r requirements/base.in
 jsonfield2==3.0.3         # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,6 @@ futures ; python_version == "2.7"
 
 # jsonfield2>3.0.3 has dropped support for python 3.5
 jsonfield2==3.0.3
+
+# Version 4.0.0 dropped support for Django < 2.0.1
+django-model-utils<4.0.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -13,7 +13,7 @@ bleach==3.1.1             # via readme-renderer
 celery==3.1.26.post2      # via -r requirements/base.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via doc8, requests
-django-model-utils==3.0.0  # via -r requirements/base.in
+django-model-utils==3.2.0  # via -r requirements/base.in
 django==2.2.11            # via -r requirements/base.in, django-model-utils, jsonfield2
 doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ billiard==3.3.0.23        # via celery
 celery==3.1.26.post2      # via -r requirements/base.in
 coverage==5.0.3           # via pytest-cov
 ddt==1.2.2                # via -r requirements/test.in
-django-model-utils==3.0.0  # via -r requirements/base.in
+django-model-utils==3.2.0  # via -r requirements/base.in
 freezegun==0.3.15         # via -r requirements/test.in
 future==0.18.2            # via -r requirements/base.in
 importlib-metadata==1.5.0  # via pluggy, pytest


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1453

We need to upgrade django-model-utils to 3.2.0 to get this Django2 fix: https://github.com/jazzband/django-model-utils/pull/335 