### PR TITLE
BOM-1584: Fixed tests for python 3.8 

### DIFF
--- a/celery_utils/persist_on_failure.py
+++ b/celery_utils/persist_on_failure.py
@@ -29,7 +29,8 @@ class PersistOnFailureTask(Task):
                 task_id=task_id,  # Fixed length UUID: No need to truncate
                 args=args,
                 kwargs=kwargs,
-                exc=_truncate_to_field(FailedTask, 'exc', repr(exc)),
+                # TODO: Remove ".replace(',', ''))" when python 3.5 support is dropped
+                exc=_truncate_to_field(FailedTask, 'exc', repr(exc).replace(',', '')),
             )
         super(PersistOnFailureTask, self).on_failure(exc, task_id, args, kwargs, einfo)
 

--- a/tests/test_persist_on_failure.py
+++ b/tests/test_persist_on_failure.py
@@ -34,10 +34,7 @@ def test_fallible_task_with_failure():
     assert failed_task_object.task_name == tasks.fallible_task.name
     assert failed_task_object.args == []
     assert failed_task_object.kwargs == {'message': 'The example task failed'}
-    if six.PY2:
-        assert failed_task_object.exc == "ValueError(u'The example task failed',)"
-    else:
-        assert failed_task_object.exc == "ValueError('The example task failed',)"
+    assert failed_task_object.exc == "ValueError('The example task failed')"
     assert failed_task_object.datetime_resolved is None
 
 
@@ -62,16 +59,11 @@ def test_persists_with_overlength_field():
     # Length is max field length
     assert len(failed_task_object.exc) == 255
     # Ellipses are put in the middle
-    if six.PY2:
-        # Ellipses offset by one due to the u' in the ValueError
-        assert failed_task_object.exc.startswith("ValueError(u'")
-        assert failed_task_object.exc[124:133] == '037...590'
-    else:
-        assert failed_task_object.exc.startswith("ValueError('")
-        assert failed_task_object.exc[124:133] == '370...590'
+    assert failed_task_object.exc.startswith("ValueError('")
+    assert failed_task_object.exc[124:133] == '370...059'
     # The beginning of the input is captured
     # The end of the input is captured
-    assert failed_task_object.exc[-9:] == "098099',)"
+    assert failed_task_object.exc[-9:] == "7098099')"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Few tests were failing on python 3.8 because of removal of trailing comma from ValueError in python 3.7 onwards.

`repr for BaseException has changed to not include the trailing comma. Most exceptions are affected by this change. (Contributed by Serhiy Storchaka in bpo-30399.)`

https://docs.python.org/3/whatsnew/3.7.html#changes-in-the-python-api

**JIRA:** [BOM-1584](https://openedx.atlassian.net/browse/BOM-1584)