### PR TITLE
[BD-6] Python 3.8 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ env:
   - TOXENV=django22
   - TOXENV=quality
   - TOXENV=docs
-jobs:
-  allow_failures:
-    - python: 3.8
 
 cache:
   - pip

--- a/setup.py
+++ b/setup.py
@@ -91,5 +91,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
**Description:** 
Update travis tests to not allow failures when using python 3.8.
Add classifier for python 3.8.

**Reviewers**
- [ ] @awais786 
- [ ] @morenol