### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[0.5.4] - 2020-11-19
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Updated the travis-badge in README.rst to point to travis-ci.com
+
 [0.5.3] - 2020-09-15
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Move to Apache 2.0 license

--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ edx-celeryutils
     :target: https://pypi.python.org/pypi/edx-celeryutils/
     :alt: PyPI
 
-.. image:: https://travis-ci.org/edx/edx-celeryutils.svg?branch=master
-    :target: https://travis-ci.org/edx/edx-celeryutils
+.. image:: https://travis-ci.com/edx/edx-celeryutils.svg?branch=master
+    :target: https://travis-ci.com/edx/edx-celeryutils
     :alt: Travis
 
 .. image:: http://codecov.io/github/edx/edx-celeryutils/coverage.svg?branch=master

--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -2,6 +2,6 @@
 Code to support working with celery.
 """
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089