### PR TITLE
Fix License classifier to fix the release failure

### DIFF
--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -2,6 +2,6 @@
 Code to support working with celery.
 """
 
-__version__ = '0.5.5'
+__version__ = '0.5.6'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache 2.0 Software License',
+        'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
[PyPI release 0.5.5](https://github.com/edx/edx-celeryutils/runs/1670498014?check_suite_focus=true) failed because of the invalid license classifier. 
Updated the license classifier according to the [PyPI classifier list](https://pypi.org/classifiers/) and bumped the version to `0.5.6`.