### PR TITLE
BOM-2213 : Remove upper constraint for Django

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
        matrix:
          os: [ubuntu-20.04]
          python-version: ['3.8']
-         toxenv: ['django22','quality','docs']
+         toxenv: ['django22','django30','quality','docs']
 
      steps:
        - uses: actions/checkout@v1

--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -2,6 +2,6 @@
 Code to support working with celery.
 """
 
-__version__ = '0.5.6'
+__version__ = '0.5.7'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/celery_utils/models.py
+++ b/celery_utils/models.py
@@ -6,7 +6,6 @@ Database models for celery_utils.
 import logging
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from celery import current_app
 from jsonfield import JSONField
@@ -17,7 +16,6 @@ from celery_utils import tasks
 log = logging.getLogger(__name__)
 
 
-@python_2_unicode_compatible
 class FailedTask(TimeStampedModel):
     """
     Representation of tasks that have failed.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,6 @@
 
 future
 celery
-Django >= 1.11 , <2.3
+Django >= 1.11
 django-model-utils
 jsonfield2


### PR DESCRIPTION
This constraint is stopping other services and packages to run tests with Django 3.0 
An example of this https://github.com/edx/enterprise-catalog/pull/232/checks?check_run_id=1680657643
Removing it to allow testing of Django 3.0

Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2213