### PR TITLE
feat: switch to jsonfield from jsonfield2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 ~~~~~~~~~~
 *
 
+[1.1.1] - 2021-08-24
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Replacing jsonfield2 with jsonfield as the former is merged back into the latter one.
+
 [1.1.0] - 2021-07-07
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Added support for django 3.1 and 3.2

--- a/celery_utils/__init__.py
+++ b/celery_utils/__init__.py
@@ -2,6 +2,6 @@
 Code to support working with celery.
 """
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 default_app_config = 'celery_utils.apps.CeleryUtilsConfig'  # pylint: disable=invalid-name

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,4 +6,4 @@ future
 celery
 Django >= 1.11
 django-model-utils
-jsonfield2
+jsonfield

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,12 +30,12 @@ django==2.2.24
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   django-model-utils
-    #   jsonfield2
+    #   jsonfield
 django-model-utils==4.1.1
     # via -r requirements/base.in
 future==0.18.2
     # via -r requirements/base.in
-jsonfield2==4.0.0.post0
+jsonfield==3.1.0
     # via -r requirements/base.in
 kombu==5.1.0
     # via celery

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,8 +14,6 @@ bleach==4.1.0
     # via readme-renderer
 certifi==2021.5.30
     # via requests
-cffi==1.14.6
-    # via cryptography
 chardet==4.0.0
     # via diff-cover
 charset-normalizer==2.0.6
@@ -67,10 +65,6 @@ isort==5.9.3
     # via
     #   -r requirements/quality.in
     #   pylint
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.1
     # via
     #   code-annotations
@@ -114,8 +108,6 @@ py==1.10.0
     # via tox
 pycodestyle==2.7.0
     # via -r requirements/quality.in
-pycparser==2.20
-    # via cffi
 pydocstyle==3.0.0
     # via -r requirements/quality.in
 pygments==2.10.0
@@ -156,8 +148,6 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==1.5.0
     # via twine
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bleach

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -40,7 +40,7 @@ django==2.2.24
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   django-model-utils
-    #   jsonfield2
+    #   jsonfield
 django-model-utils==4.1.1
     # via -r requirements/base.in
 doc8==0.9.1
@@ -61,7 +61,7 @@ imagesize==1.2.0
     # via sphinx
 jinja2==3.0.1
     # via sphinx
-jsonfield2==4.0.0.post0
+jsonfield==3.1.0
     # via -r requirements/base.in
 kombu==5.1.0
     # via celery

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -32,7 +32,7 @@ ddt==1.4.3
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   django-model-utils
-    #   jsonfield2
+    #   jsonfield
 django-model-utils==4.1.1
     # via -r requirements/base.in
 freezegun==1.1.0
@@ -41,7 +41,7 @@ future==0.18.2
     # via -r requirements/base.in
 iniconfig==1.1.1
     # via pytest
-jsonfield2==4.0.0.post0
+jsonfield==3.1.0
     # via -r requirements/base.in
     # via celery
 mock==4.0.3


### PR DESCRIPTION
**Description:** Looks like https://pypi.org/project/jsonfield2/ was archived and merged back into `jsonfield` so need to switch back to the original package.


**Reviewers:**
- [ ] tag reviwer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
