### PR TITLE
Dropped django 4.2 support. Bumped dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12']
-        toxenv: [quality, docs, django42, django52]
+        toxenv: [quality, docs, django52]
 
     steps:
     - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
       run: tox
 
     - name: Run coverage
-      if: matrix.python-version == '3.12' && matrix.toxenv == 'django42'
+      if: matrix.python-version == '3.12' && matrix.toxenv == 'django52'
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+* Dropped Django 4.2 support; bumped celery 5.5→5.6.2, jsonfield 3.1→3.2, pip to 26.0.1; loosened Django constraint to <6.0
+
 [1.4.0] - 2024-03-31
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Added django5.2 support. Adding new migration with index_together change.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,15 +6,15 @@
 #
 amqp==5.3.1
     # via kombu
-asgiref==3.8.1
+asgiref==3.11.1
     # via django
-billiard==4.2.1
+billiard==4.2.4
     # via celery
-celery==5.5.1
+celery==5.6.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-click==8.1.8
+click==8.3.1
     # via
     #   celery
     #   click-didyoumean
@@ -22,11 +22,11 @@ click==8.1.8
     #   click-repl
 click-didyoumean==0.3.1
     # via celery
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-django==4.2.20
+django==5.2.12
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -34,24 +34,28 @@ django==4.2.20
     #   jsonfield
 django-model-utils==5.0.0
     # via -r requirements/base.in
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via -r requirements/base.in
-kombu==5.5.3
+kombu==5.6.2
     # via celery
-prompt-toolkit==3.0.51
+packaging==26.0
+    # via kombu
+prompt-toolkit==3.0.52
     # via click-repl
 python-dateutil==2.9.0.post0
     # via celery
 six==1.17.0
     # via python-dateutil
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-tzdata==2025.2
+tzdata==2025.3
     # via kombu
+tzlocal==5.3.1
+    # via celery
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via prompt-toolkit

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,9 +1,9 @@
 amqp==5.3.1
-billiard==4.2.1
-celery==5.5.1
-click==8.1.8
+billiard==4.2.4
+celery==5.6.2
+click==8.3.1
 click-didyoumean==0.3.1
 click-repl==0.3.0
-kombu==5.5.3
-prompt-toolkit==3.0.51
+kombu==5.6.2
+prompt-toolkit==3.0.52
 vine==5.1.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,31 +4,35 @@
 #
 #    make upgrade
 #
-cachetools==5.5.2
-    # via tox
-chardet==5.2.0
+cachetools==7.0.5
     # via tox
 colorama==0.4.6
     # via tox
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
-filelock==3.18.0
+filelock==3.25.2
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
-packaging==25.0
+packaging==26.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.7
+platformdirs==4.9.4
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via tox
-pyproject-api==1.9.0
+pyproject-api==1.10.0
     # via tox
-tox==4.25.0
+python-discovery==1.2.0
+    # via virtualenv
+tomli-w==1.2.0
+    # via tox
+tox==4.50.3
     # via -r requirements/ci.in
-virtualenv==20.30.0
+virtualenv==21.2.0
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -12,20 +12,9 @@
 #  this file from Github directly. It does not require packaging in edx-lint.
 
 # using LTS django version
-Django<5.0
+Django<6.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
-
-# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-django-simple-history==3.0.0
-
-# Cause: https://github.com/openedx/edx-lint/issues/458
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
-pip<24.3
-
-# Cause: https://github.com/openedx/edx-lint/issues/475
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-urllib3<2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,129 +4,128 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+asgiref==3.11.1
     # via django
-astroid==3.3.9
+astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
 backports-tarfile==1.2.0
     # via jaraco-context
-cachetools==5.5.2
+cachetools==7.0.5
     # via tox
-certifi==2025.1.31
+certifi==2026.2.25
     # via requests
-chardet==5.2.0
-    # via
-    #   diff-cover
-    #   tox
-charset-normalizer==3.4.1
+chardet==7.3.0
+    # via diff-cover
+charset-normalizer==3.4.6
     # via requests
-click==8.1.8
+click==8.3.1
     # via
     #   click-log
     #   code-annotations
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via edx-lint
 colorama==0.4.6
     # via tox
-diff-cover==9.2.4
+diff-cover==10.2.0
     # via -r requirements/dev.in
-dill==0.4.0
+dill==0.4.1
     # via pylint
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
-django==4.2.20
+django==5.2.12
     # via
     #   -c requirements/common_constraints.txt
     #   edx-i18n-tools
-docutils==0.21.2
+docutils==0.22.4
     # via readme-renderer
-edx-i18n-tools==1.8.0
+edx-i18n-tools==2.0.0
     # via -r requirements/dev.in
-edx-lint==5.6.0
+edx-lint==6.0.0
     # via
     #   -r requirements/dev.in
     #   -r requirements/quality.in
-filelock==3.18.0
+filelock==3.25.2
     # via
+    #   python-discovery
     #   tox
     #   virtualenv
-id==1.5.0
+id==1.6.1
     # via twine
-idna==3.10
+idna==3.11
     # via requests
-importlib-metadata==8.6.1
+importlib-metadata==9.0.0
     # via keyring
-isort==6.0.1
+isort==8.0.1
     # via
     #   -r requirements/quality.in
     #   pylint
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.4.0
     # via keyring
 jinja2==3.1.6
     # via
     #   code-annotations
     #   diff-cover
-keyring==25.6.0
+keyring==25.7.0
     # via twine
-lxml[html-clean,html_clean]==5.4.0
+lxml[html-clean]==6.0.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
-lxml-html-clean==0.4.2
+lxml-html-clean==0.4.4
     # via lxml
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.2.21
+nh3==0.3.4
     # via readme-renderer
-packaging==25.0
+packaging==26.0
     # via
     #   pyproject-api
     #   tox
     #   twine
+    #   wheel
 path==16.16.0
     # via edx-i18n-tools
-pbr==6.1.1
-    # via stevedore
-platformdirs==4.3.7
+platformdirs==4.9.4
     # via
     #   pylint
+    #   python-discovery
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   diff-cover
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/quality.in
 pydocstyle==3.0.0
     # via -r requirements/quality.in
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==3.3.6
+pylint==4.0.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -134,62 +133,62 @@ pylint==3.3.6
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
-pyproject-api==1.9.0
+pyproject-api==1.10.0
     # via tox
+python-discovery==1.2.0
+    # via virtualenv
 python-slugify==8.0.4
     # via code-annotations
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via
     #   code-annotations
     #   edx-i18n-tools
 readme-renderer==44.0
     # via twine
-requests==2.32.3
+requests==2.33.0
     # via
-    #   id
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.3.3
     # via twine
 six==1.17.0
     # via
     #   edx-lint
     #   pydocstyle
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via pydocstyle
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.4.1
+stevedore==5.7.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.13.2
+tomli-w==1.2.0
+    # via tox
+tomlkit==0.14.0
     # via pylint
-tox==4.25.0
+tox==4.50.3
     # via -r requirements/dev.in
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/dev.in
-urllib3==2.2.3
+urllib3==2.6.3
     # via
-    #   -c requirements/common_constraints.txt
+    #   id
     #   requests
     #   twine
-virtualenv==20.30.0
+virtualenv==21.2.0
     # via tox
-wheel==0.45.1
+wheel==0.46.3
     # via -r requirements/dev.in
-zipp==3.21.0
+zipp==3.23.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,29 +10,29 @@ alabaster==1.0.0
     # via sphinx
 amqp==5.3.1
     # via kombu
-asgiref==3.8.1
+asgiref==3.11.1
     # via django
-babel==2.17.0
+babel==2.18.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
-beautifulsoup4==4.13.4
+beautifulsoup4==4.14.3
     # via pydata-sphinx-theme
-billiard==4.2.1
+billiard==4.2.4
     # via celery
-build==1.2.2.post1
+build==1.4.2
     # via -r requirements/doc.in
-celery==5.5.1
+celery==5.6.2
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-certifi==2025.1.31
+certifi==2026.2.25
     # via requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.6
     # via requests
-click==8.1.8
+click==8.3.1
     # via
     #   celery
     #   click-didyoumean
@@ -40,11 +40,11 @@ click==8.1.8
     #   click-repl
 click-didyoumean==0.3.1
     # via celery
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-django==4.2.20
+django==5.2.12
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -52,7 +52,7 @@ django==4.2.20
     #   jsonfield
 django-model-utils==5.0.0
     # via -r requirements/base.in
-doc8==1.1.2
+doc8==2.0.0
     # via -r requirements/doc.in
 docutils==0.21.2
     # via
@@ -61,55 +61,53 @@ docutils==0.21.2
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-id==1.5.0
+id==1.6.1
     # via twine
-idna==3.10
+idna==3.11
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
-importlib-metadata==8.6.1
+importlib-metadata==9.0.0
     # via keyring
 jaraco-classes==3.4.0
     # via keyring
-jaraco-context==6.0.1
+jaraco-context==6.1.2
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.4.0
     # via keyring
 jinja2==3.1.6
     # via sphinx
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via -r requirements/base.in
-keyring==25.6.0
+keyring==25.7.0
     # via twine
-kombu==5.5.3
+kombu==5.6.2
     # via celery
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.7.0
+more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-nh3==0.2.21
+nh3==0.3.4
     # via readme-renderer
-packaging==25.0
+packaging==26.0
     # via
     #   build
-    #   pydata-sphinx-theme
+    #   kombu
     #   sphinx
     #   twine
-pbr==6.1.1
-    # via stevedore
 pockets==0.9.1
     # via sphinxcontrib-napoleon
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via click-repl
-pydata-sphinx-theme==0.15.4
+pydata-sphinx-theme==0.16.1
     # via sphinx-book-theme
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   accessible-pygments
     #   doc8
@@ -123,37 +121,36 @@ python-dateutil==2.9.0.post0
     # via celery
 readme-renderer==44.0
     # via twine
-requests==2.32.3
+requests==2.33.0
     # via
-    #   id
     #   requests-toolbelt
     #   sphinx
     #   twine
 requests-toolbelt==1.0.0
     # via twine
-restructuredtext-lint==1.4.0
+restructuredtext-lint==2.0.2
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.3.3
     # via twine
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
 six==1.17.0
     # via
     #   pockets
     #   python-dateutil
     #   sphinxcontrib-napoleon
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.7
+soupsieve==2.8.3
     # via beautifulsoup4
-sphinx==8.2.3
+sphinx==9.0.4
     # via
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.1.4
+sphinx-book-theme==1.2.0
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -169,21 +166,23 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-stevedore==5.4.1
+stevedore==5.7.0
     # via doc8
-twine==6.1.0
+twine==6.2.0
     # via -r requirements/doc.in
-typing-extensions==4.13.2
+typing-extensions==4.15.0
     # via
     #   beautifulsoup4
     #   pydata-sphinx-theme
-tzdata==2025.2
+tzdata==2025.3
     # via kombu
-urllib3==2.2.3
+tzlocal==5.3.1
+    # via celery
+urllib3==2.6.3
     # via
-    #   -c requirements/common_constraints.txt
+    #   id
     #   requests
     #   twine
 vine==5.1.0
@@ -191,10 +190,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via prompt-toolkit
-zipp==3.21.0
+zipp==3.23.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,19 +4,21 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.4.2
     # via pip-tools
-click==8.1.8
+click==8.3.1
     # via pip-tools
-packaging==25.0
-    # via build
-pip-tools==7.4.1
+packaging==26.0
+    # via
+    #   build
+    #   wheel
+pip-tools==7.5.3
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.45.1
+wheel==0.46.3
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-wheel==0.45.1
+packaging==26.0
+    # via wheel
+wheel==0.46.3
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/pip.in
-setuptools==79.0.0
+pip==26.0.1
+    # via -r requirements/pip.in
+setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,42 +4,40 @@
 #
 #    make upgrade
 #
-astroid==3.3.9
+astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
-click==8.1.8
+click==8.3.1
     # via
     #   click-log
     #   code-annotations
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.3.0
+code-annotations==2.3.2
     # via edx-lint
-dill==0.4.0
+dill==0.4.1
     # via pylint
-edx-lint==5.6.0
+edx-lint==6.0.0
     # via -r requirements/quality.in
-isort==6.0.1
+isort==8.0.1
     # via
     #   -r requirements/quality.in
     #   pylint
 jinja2==3.1.6
     # via code-annotations
-markupsafe==3.0.2
+markupsafe==3.0.3
     # via jinja2
 mccabe==0.7.0
     # via pylint
-pbr==6.1.1
-    # via stevedore
-platformdirs==4.3.7
+platformdirs==4.9.4
     # via pylint
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/quality.in
 pydocstyle==3.0.0
     # via -r requirements/quality.in
-pylint==3.3.6
+pylint==4.0.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -47,28 +45,25 @@ pylint==3.3.6
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.6.1
+pylint-django==2.7.0
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
 python-slugify==8.0.4
     # via code-annotations
-pyyaml==6.0.2
+pyyaml==6.0.3
     # via code-annotations
 six==1.17.0
     # via
     #   edx-lint
     #   pydocstyle
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via pydocstyle
-stevedore==5.4.1
+stevedore==5.7.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.13.2
+tomlkit==0.14.0
     # via pylint
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,13 +5,13 @@
 #    make upgrade
 #
     # via kombu
-asgiref==3.8.1
+asgiref==3.11.1
     # via django
     # via celery
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-click==8.1.8
+click==8.3.1
     # via
     #   celery
     #   click-didyoumean
@@ -19,11 +19,11 @@ click==8.1.8
     #   click-repl
 click-didyoumean==0.3.1
     # via celery
-click-plugins==1.1.1
+click-plugins==1.1.1.2
     # via celery
 click-repl==0.3.0
     # via celery
-coverage[toml]==7.8.0
+coverage[toml]==7.13.5
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
@@ -34,28 +34,34 @@ ddt==1.7.2
     #   jsonfield
 django-model-utils==5.0.0
     # via -r requirements/base.in
-freezegun==1.5.1
+freezegun==1.5.5
     # via -r requirements/test.in
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via -r requirements/base.in
     # via celery
 mock==5.2.0
     # via -r requirements/test.in
-packaging==25.0
-    # via pytest
-pluggy==1.5.0
-    # via pytest
-prompt-toolkit==3.0.51
+packaging==26.0
+    # via
+    #   kombu
+    #   pytest
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+prompt-toolkit==3.0.52
     # via click-repl
-pytest==8.3.5
+pygments==2.19.2
+    # via pytest
+pytest==9.0.2
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.1.1
+pytest-cov==7.1.0
     # via -r requirements/test.in
-pytest-django==4.11.1
+pytest-django==4.12.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
@@ -65,13 +71,15 @@ python-memcached==1.62
     # via -r requirements/test.in
 six==1.17.0
     # via python-dateutil
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via django
-tzdata==2025.2
+tzdata==2025.3
     # via kombu
+tzlocal==5.3.1
+    # via celery
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.13
+wcwidth==0.6.0
     # via prompt-toolkit

--- a/setup.py
+++ b/setup.py
@@ -147,14 +147,12 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
-        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
-        'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.2',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,312}-celery{53}-django{42,52},quality,docs
+envlist = py{311,312}-celery{53}-django{52},quality,docs
 
 [doc8]
 ignore = D001
@@ -19,7 +19,6 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps = 
-    django42: Django>=4.2,<4.3
     django52: Django>=5.2,<5.3
     celery53: -r{toxinidir}/requirements/celery53.txt
     -r{toxinidir}/requirements/test.txt


### PR DESCRIPTION
**Description:** ran make upgrade and removed django 4.2 support
Issue: https://github.com/openedx/public-engineering/issues/458

**JIRA:** N/A

**Dependencies:** N/A

**Merge deadline:** N/A

**Installation instructions:** N/A

**Testing instructions:**
N/A

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [x] Changelog record added
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
